### PR TITLE
prefer `export.companionFileTemplatePath` if the value is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See the example config in the `samples` directory.
       exports of raster graphics. Ignored if `rasterScales` is defined
     - `companionFileName`: The name of the generated companion file. A `/` will
       cause a directory to be created. If this is set `companionFileTemplatePath` is required
-    - `companionFileTemplatePath`: The path to the Jinja2 template. See `samples/Contents.json.figex` for an example and see below for more details. If `companionFileName` is not set, this value is ignored
+    - `companionFileTemplatePath`: The path to the Jinja2 template. See `samples/Contents.json.figex` for an example and see below for more details. If `companionFileName` or `useXcodeAssetCompanionFile` are not set, this value is ignored
     - `useXcodeAssetCompanionFile`: A shorthand to create xcode assets `Contents.json` companion files. Ignored if `companionFileName` is set
 
 ## Templating

--- a/figex-core/src/main/kotlin/com/iodigital/figex/IconExports.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/IconExports.kt
@@ -122,14 +122,9 @@ private fun generateCompanionFile(
     val fileName = export.companionFileName
         ?: COMPANION_FILENAME_XCODE_ASSETS.takeIf { export.useXcodeAssetCompanionFile }
         ?: return
-    val fileContent = when (fileName) {
-        COMPANION_FILENAME_XCODE_ASSETS -> xcodeAssetsContentJSON
-        else -> requireNotNull(export.companionFileTemplatePath) {
-            "When companionFileName is defined, companionFileTemplatePath is required but currently null"
-        }.let {
-            root.makeChild(it).readText()
-        }
-    }
+
+    val fileContent = export.companionFileTemplatePath?.let { root.makeChild(it).readText() }
+        ?: xcodeAssetsContentJSON
 
     verbose(tag = tag, message = "  Generating companion file: ${exportSet.component.fullName}")
     val companionFile = outFile.parentFile.makeChild(fileName)


### PR DESCRIPTION
This is how the functionality actually should work, 

I want the following to also work:
* I want the parent directories, to get the correct Contents.json file (which is driven by `useXcodeAssetCompanionFile`)
*  I also want to be able to use a custom companion template, which get ignored when I pass true for `useXcodeAssetCompanionFile`

alternatives:

1. * add a new flag to the Config which indicates these Content.json files for directories need to be created
2. * add a new flag that indicates we should prefer the companionFileTemplatePath over the one provided when you set `useXcodeAssetCompanionFile` to true

These options add more flags to the config, so I opted for the solution I provided in this PR