### PR TITLE
Bug fixes

### DIFF
--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
@@ -55,6 +55,7 @@ import java.io.OutputStream
 import java.lang.Math.random
 import java.util.Collections.emptyList
 import java.util.Collections.emptyMap
+import kotlin.collections.flatten
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(FlowPreview::class)
@@ -134,12 +135,17 @@ class FigmaApi(
             return@withRateLimit FigmaNodesList(emptyMap())
         }
 
-        httpClient.get {
-            figmaRequest("v1/files/$fileKey/nodes")
-            parameter("ids", ids.joinToString(","))
-        }.body<FigmaNodesList>().let { list ->
-            val withCached = list.copy(nodes = list.nodes)
-            withCached.resolveNestedReferences(this, emptyList())
+        ids.chunked(100).map { idsChunk ->
+            httpClient.get {
+                figmaRequest("v1/files/$fileKey/nodes")
+                parameter("ids", idsChunk.joinToString(","))
+            }.body<FigmaNodesList>()
+        }.flatMap {
+            it.nodes.entries
+        }.associate {
+            it.key to it.value
+        }.let {
+            FigmaNodesList(it).resolveNestedReferences(this, emptyList(), ignoreUnsupportedLinks)
         }
     }
 
@@ -201,22 +207,24 @@ class FigmaApi(
     ) {
         withContext(Dispatchers.IO) {
             val downloadUrls = withRateLimit {
-                httpClient.get {
-                    figmaRequest("v1/images/$fileKey")
-                    parameter("ids", ids.joinToString(","))
-                    parameter("scale", scale)
-                    parameter(
-                        key = "format",
-                        value = when (format) {
-                            Svg, AndroidXml -> "svg"
-                            Png, Webp -> "png"
-                            Pdf -> "pdf"
-                        }
-                    )
-                }.body<FigmaImageExport>().let { body ->
+                ids.chunked(100).map { idsChunk ->
+                    httpClient.get {
+                        figmaRequest("v1/images/$fileKey")
+                        parameter("ids", idsChunk.joinToString(","))
+                        parameter("scale", scale)
+                        parameter(
+                            key = "format",
+                            value = when (format) {
+                                Svg, AndroidXml -> "svg"
+                                Png, Webp -> "png"
+                                Pdf -> "pdf"
+                            }
+                        )
+                    }.body<FigmaImageExport>()
+                }.flatMap { body ->
                     require(body.err == null) { "Figma reported error while loading components $ids: ${body.err}" }
-                    body.images
-                }
+                    body.images.entries.mapNotNull { (id, downloadUrl) -> downloadUrl?.let { id to it} }
+                }.toMap()
             }
 
             downloadUrls.map { (id, downloadUrl) ->
@@ -309,15 +317,8 @@ class FigmaApi(
         throw IOException("Failed to check if cwebp is installed: ${e.message}", e)
     }
 
-    private val FigmaVariableReference.WithPath.plainIdOrNull
-        get() = try {
-            plainId
-        } catch (e: UnsupportedExternalLinkException) {
-            if (ignoreUnsupportedLinks) {
-                warning(tag = tag, message = "Ignoring unsupported external link: ${e.description}")
-                null
-            } else {
-                throw e
-            }
+    private val FigmaVariableReference.WithPath.plainIdOrNull get() =
+        plainIdOrNull(ignoreUnsupportedLinks).also {
+           if (it == null) warning(tag = tag, message = "Unsupported external link: $path")
         }
 }

--- a/figex-core/src/main/kotlin/com/iodigital/figex/ext/FigmaNodeListExt.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/ext/FigmaNodeListExt.kt
@@ -1,13 +1,18 @@
 package com.iodigital.figex.ext
 
 import com.iodigital.figex.api.FigmaApi
+import com.iodigital.figex.exceptions.UnsupportedExternalLinkException
 import com.iodigital.figex.models.figma.FigmaNodesList
+import com.iodigital.figex.models.figma.FigmaVariableReference
 import com.iodigital.figex.models.figma.FigmaVariableValue
 import com.iodigital.figex.models.figma.FigmaVariableValueCollection
+import com.iodigital.figex.utils.warning
+import kotlin.collections.mapNotNullTo
 
 internal suspend fun FigmaNodesList.resolveNestedReferences(
     api: FigmaApi,
-    path: List<String>
+    path: List<String>,
+    ignoreUnsupportedLinks: Boolean,
 ): FigmaNodesList {
     val nestedReferences = nodes.flatMap { (name, value) ->
         val referenced = value.document.valuesByMode?.mapNotNull { (_, it) ->
@@ -23,15 +28,17 @@ internal suspend fun FigmaNodesList.resolveNestedReferences(
     return if (nestedReferences.isEmpty()) {
         this
     } else {
-        val resolvedNested = api.loadNodes(nestedReferences.map { it.plainId }.toSet())
+        val resolvedNested = api.loadNodes(nestedReferences.mapNotNull { it.plainIdOrNull(ignoreUnsupportedLinks) }.toSet())
         val nodes = nodes.mapValues { (key, value) ->
-            val mappedValues = value.document.valuesByMode?.mapValues { (mode, value) ->
-                value.resolveSingle(mode, this + resolvedNested, path + key)
-            }
+            val mappedValues = value.document.valuesByMode?.mapNotNull { (mode, value) ->
+                value.resolveSingle(mode, this + resolvedNested, path + key, ignoreUnsupportedLinks)?.let { resolvedValue ->
+                    mode to resolvedValue
+                }
+            }?.toMap()
 
             val boundVariablesByMode = value.document.boundVariables?.mapValues { (key, values) ->
-                values.map { it.resolveMulti(resolvedNested, path + key) }
-                    .reduceRight { map, acc -> acc + map }
+                val resolvedValues = values.mapNotNull { it.resolveMulti(resolvedNested, path + key, ignoreUnsupportedLinks) } + emptyMap()
+                resolvedValues.reduceRight { map, acc -> acc + map }
             }
 
             value.copy(
@@ -49,26 +56,29 @@ internal suspend fun FigmaNodesList.resolveNestedReferences(
 private fun FigmaVariableValue.resolveSingle(
     mode: String,
     values: FigmaNodesList,
-    path: List<String>
-) = if (this is FigmaVariableValue.Reference) {
-    val id = reference.atPath(path).plainId
-    val resolved = requireNotNull(values.nodes[id]) {
-        "Missing resolved value for $id"
-    }
-    val valueForMode = resolved.document.valuesByMode?.get(mode)
-    require(valueForMode != null || resolved.document.valuesByMode?.values?.size == 1) {
-        "Expected a match for mode $mode or exactly one mode for ${resolved.document.name} as it's referenced by another variable"
-    }
-    requireNotNull(valueForMode ?: resolved.document.valuesByMode?.values?.first()) {
-        "Failed to get first value for ${resolved.document.name}"
-    }
-} else {
-    this
-}
-
-private fun FigmaVariableValue.resolveMulti(values: FigmaNodesList, path: List<String>) =
+    path: List<String>,
+    ignoreUnsupportedLinks: Boolean,
+): FigmaVariableValue? =
     if (this is FigmaVariableValue.Reference) {
-        val id = reference.atPath(path).plainId
+        val id = reference.atPath(path).plainIdOrNull(ignoreUnsupportedLinks) ?: return null
+        val resolved = requireNotNull(values.nodes[id]) {
+            "Missing resolved value for $id"
+        }
+        val valueForMode = resolved.document.valuesByMode?.get(mode)
+        requireNotNull(valueForMode ?: resolved.document.valuesByMode?.values?.first()) {
+            "Failed to get first value for ${resolved.document.name}"
+        }
+    } else {
+        this
+    }
+
+private fun FigmaVariableValue.resolveMulti(
+    values: FigmaNodesList,
+    path: List<String>,
+    ignoreUnsupportedLinks: Boolean,
+): Map<String, FigmaVariableValue>? =
+    if (this is FigmaVariableValue.Reference) {
+        val id = reference.atPath(path).plainIdOrNull(ignoreUnsupportedLinks) ?: return null
         val resolved = requireNotNull(values.nodes[id]) {
             "Missing resolved value for $id"
         }

--- a/figex-core/src/main/kotlin/com/iodigital/figex/models/figma/FigmaImageExport.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/models/figma/FigmaImageExport.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class FigmaImageExport(
     val err: String?,
-    val images: Map<String, String>,
+    val images: Map<String, String?>,
 )

--- a/figex-core/src/main/kotlin/com/iodigital/figex/models/figma/FigmaVariableReference.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/models/figma/FigmaVariableReference.kt
@@ -28,5 +28,13 @@ internal data class FigmaVariableReference(
             } else {
                 id.removePrefix("VariableID:")
             }
+
+        fun plainIdOrNull(ignoreUnsupportedLinks: Boolean) =
+            try {
+                plainId
+            } catch (e: UnsupportedExternalLinkException) {
+                if (!ignoreUnsupportedLinks) throw e
+                null
+            }
     }
 }


### PR DESCRIPTION
We had several issues while attempting to process our Figma design with FixEx.

We resolved the following issues:
* When the list of node ids would become to large the query parameter that holds the node ids would become to large. We adapted the requests to get the nodes and the images to chunk the ids in chunks of 100
* Checking `ignoreUnsupportedLinks` in `FigmaNodesList.resolveNestedReferences`
* Figma can return null download url in FigmaImageExport 