### PR TITLE
Shadow JAR for gradle-plugin to fix Kotlin version clash

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-gradle-plugin`
     kotlin("jvm")
+    alias(libs.plugins.shadow)
     id("com.gradle.plugin-publish") version "1.2.1"
     `maven-publish`
 }
@@ -9,6 +10,7 @@ dependencies {
     // Use JUnit test framework for unit tests
     testImplementation(libs.junit)
     testImplementation(libs.truth)
+    testImplementation(gradleTestKit())
     implementation(kotlin("stdlib-jdk8"))
     implementation(project(":figex-core"))
 }
@@ -26,6 +28,55 @@ gradlePlugin {
         displayName = "Gradle Figma Exporter"
         description = "Export colors, floats, icons and text styles from Figma design files"
         tags = listOf("figma", "export", "design", "icons")
+    }
+}
+
+// Shadow JAR configuration: bundles all dependencies and relocates their packages
+// to avoid conflicts with Gradle's embedded kotlin-stdlib.
+// See PROBLEM_ANALYSIS.md for details on why this is needed.
+tasks.shadowJar {
+    archiveClassifier.set("")
+
+    val prefix = "com.iodigital.figex.shadow"
+
+    // Kotlin stdlib & coroutines
+    relocate("kotlin", "$prefix.kotlin")
+    relocate("kotlinx", "$prefix.kotlinx")
+
+    // Ktor HTTP client
+    relocate("io.ktor", "$prefix.io.ktor")
+
+    // OkHttp + Okio (Ktor engine)
+    relocate("okhttp3", "$prefix.okhttp3")
+    relocate("okio", "$prefix.okio")
+
+    // Jinjava template engine + transitive deps
+    relocate("com.hubspot.jinjava", "$prefix.com.hubspot.jinjava")
+    relocate("com.google", "$prefix.com.google")
+    relocate("com.fasterxml", "$prefix.com.fasterxml")
+    relocate("org.jsoup", "$prefix.org.jsoup")
+    relocate("javassist", "$prefix.javassist")
+
+    // Logging
+    relocate("org.slf4j", "$prefix.org.slf4j")
+
+    mergeServiceFiles()
+}
+
+// Disable the standard jar — shadowJar replaces it as the main artifact
+tasks.jar {
+    enabled = false
+}
+
+// Wire the shadow JAR into configurations so publications and tests use it
+afterEvaluate {
+    configurations.apiElements.get().outgoing.apply {
+        artifacts.clear()
+        artifact(tasks.shadowJar)
+    }
+    configurations.runtimeElements.get().outgoing.apply {
+        artifacts.clear()
+        artifact(tasks.shadowJar)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ jinjava = "2.7.2"
 maven = "0.32.0"
 trurh = "1.4.2"
 junit = "4.13"
+shadow = "8.3.6"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -28,3 +29,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 mavenPublishing = { id = "com.vanniktech.maven.publish", version.ref = "maven" }
 jetbrainsKotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
## Summary
- Adds the [Shadow JAR](https://github.com/GradleUp/shadow) plugin (`8.3.6`) to the `gradle-plugin` module to bundle and relocate all dependencies under `com.iodigital.figex.shadow.*`
- Prevents runtime conflicts between the plugin's Kotlin stdlib/coroutines and Gradle's own embedded Kotlin runtime
- Relocates Kotlin, Ktor, OkHttp/Okio, Jinjava (+ transitive deps), and SLF4J