### PR TITLE
Fix Android raster scales broken — only mdpi exported

### DIFF
--- a/figex-core/src/main/kotlin/com/iodigital/figex/IconExports.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/IconExports.kt
@@ -61,7 +61,7 @@ internal suspend fun performIconExport(
             context = context
         )
     }.distinctBy {
-        it.component.key
+        it.component.key to it.scale
     }.groupBy {
         it.scale
     }.toList().map { (scale, exportSets) ->


### PR DESCRIPTION
The batch request refactoring (f1858d8) introduced a bug where only mdpi scale assets were exported for Android raster icons, silently dropping hdpi, xhdpi, xxhdpi, and xxxhdpi.

The original code used `.also { export -> export.distinctBy { ... } }`, where the `.also` block discarded the distinctBy result and returned the original list — making it a no-op. The refactored code chained `.distinctBy { it.component.key }` directly in the pipeline, which actually filtered. Since the key was only `component.key` (without scale), it collapsed all 5 scale variants of the same component down to just the first one (mdpi).

Fix: include scale in the distinctBy key (`component.key to scale`) so deduplication is per component+scale, preserving all scale variants.