### PR TITLE
Improve modes check

### DIFF
--- a/figex-core/build.gradle.kts
+++ b/figex-core/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
     testImplementation(libs.kotlin.test)
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 mavenPublishing {
     coordinates("com.iodigital", "figex-core", version as String)
 }

--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
@@ -1,6 +1,5 @@
 package com.iodigital.figex.api
 
-import com.iodigital.figex.exceptions.UnsupportedExternalLinkException
 import com.iodigital.figex.ext.asFigExComponents
 import com.iodigital.figex.ext.asFigExTextStyle
 import com.iodigital.figex.ext.asFigExValue
@@ -55,7 +54,6 @@ import java.io.OutputStream
 import java.lang.Math.random
 import java.util.Collections.emptyList
 import java.util.Collections.emptyMap
-import kotlin.collections.flatten
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(FlowPreview::class)
@@ -65,6 +63,9 @@ class FigmaApi(
     private val scope: CoroutineScope,
     private val ignoreUnsupportedLinks: Boolean,
 ) : FigmaImageExporter {
+    companion object {
+        private const val IDS_CHUNK_SIZE = 30
+    }
     private val tag = "FigmaApi"
     private val httpClient by lazy { HttpClientFactory.createClient() }
     private val rateLimitReached = MutableStateFlow(false)
@@ -135,7 +136,7 @@ class FigmaApi(
             return@withRateLimit FigmaNodesList(emptyMap())
         }
 
-        ids.chunked(100).map { idsChunk ->
+        ids.chunked(IDS_CHUNK_SIZE).map { idsChunk ->
             httpClient.get {
                 figmaRequest("v1/files/$fileKey/nodes")
                 parameter("ids", idsChunk.joinToString(","))
@@ -207,7 +208,7 @@ class FigmaApi(
     ) {
         withContext(Dispatchers.IO) {
             val downloadUrls = withRateLimit {
-                ids.chunked(100).map { idsChunk ->
+                ids.chunked(IDS_CHUNK_SIZE).map { idsChunk ->
                     httpClient.get {
                         figmaRequest("v1/images/$fileKey")
                         parameter("ids", idsChunk.joinToString(","))

--- a/figex-core/src/main/kotlin/com/iodigital/figex/ext/FigmaNodeExt.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/ext/FigmaNodeExt.kt
@@ -1,12 +1,10 @@
 package com.iodigital.figex.ext
 
 import com.iodigital.figex.models.figex.FigExArgbColor
-import com.iodigital.figex.models.figex.FigExComponent
 import com.iodigital.figex.models.figex.FigExTextStyle
 import com.iodigital.figex.models.figex.FigExValue
 import com.iodigital.figex.models.figma.FigmaNode
 import com.iodigital.figex.models.figma.FigmaNode.ResolvedType.*
-import com.iodigital.figex.models.figma.FigmaVariableValue
 
 internal fun FigmaNode.asFigExValue(): FigExValue<*> = with(document) {
     val values = valuesByMode ?: throw IllegalArgumentException("No values for $name")
@@ -69,7 +67,15 @@ internal fun FigmaNode.asFigExTextStyle(): FigExValue<FigExTextStyle> = with(doc
     }
 
     val modes = boundValuesByMode.values.map { it.keys }
-    require(modes.distinct().size == 1) { "Expected all bound values to have the same modes" }
+    val amountOfModes = modes.distinct().map { it.size }
+    require(amountOfModes.size == 1 || amountOfModes.count { it != 1 } <= 1) {
+        val faultyProperties = boundValuesByMode.filter { it.value.keys.size != 1 && it.value.keys.size != amountOfModes.max() }
+        val expectedMode = boundValuesByMode.filter {
+            it.value.size == amountOfModes.max()
+        }.values.first()
+        "Properties ${faultyProperties.keys} in style '$name' have an unexpected number of modes. Expected: $expectedMode. Received: ${faultyProperties.values}"
+    }
+
     val definitiveModes = modes.first()
 
     return FigExValue(


### PR DESCRIPTION
When loading the text styles every property was checked if every mode was present. For example: if there are 3 modes set in Figma, fontFamily should have 3, fontSize should have 3, etc.

In our case we had one property set to a primitive. Therefore one property had 1 mode which threw the error "Expected all bound values to have the same modes".

We wanted to improve the error but also allow it when there is only one (a default) mode set in the property. 

With this change, it will fail if one of the properties had a different amount of modes, but greater than one. 


Also some small improvements are added: 
- Decreased the chunk kize to 30 when loading ids
- Make sure figex core is also compiling on java 17