### PR TITLE
Template lookup for filters and fileNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ See the example config in the `samples` directory.
     - `destinationPaths`: A list of paths to where the generated file should be written
     - `defaultMode`: The default mode to be used for the values. If the `defaultMode` is e.g. `test` then `color.test.argb` is the same as `color.argb`
     - `templateVariables`: A map of extra variables for the template. If you define `test` here you can later use `{{ test }}` in your template file
-    - `filter`: A template that should read `true` to include a value in the export
+    - `filter`: A template or template reference that should read `true` to include a value in the export
   - `"type": "icons"` is used to export icons and illustrations
     - `format`: One of `svg`, `pdf`, `png`, `webp` or `androidxml` (`webp` requires the [`cwebp`](https://formulae.brew.sh/formula/webp) tool to be installed)
-    - `filter`: A template that should read `true` to include a component in the export
-    - `fileNames`: A template defining the file name of the exported component. A `/` will cause a
+    - `filter`: A template or template reference that should read `true` to include a component in the export
+    - `fileNames`: A template or template reference defining the file name of the exported component. A `/` will cause a
       directory to be created
     - `destinationPath`: The path to where the generated file should be written
     - `destinationPaths`: A list of paths to where the generated file should be written
@@ -188,6 +188,7 @@ See the example config in the `samples` directory.
       cause a directory to be created. If this is set `companionFileTemplatePath` is required
     - `companionFileTemplatePath`: The path to the Jinja2 template. See `samples/Contents.json.figex` for an example and see below for more details. If `companionFileName` or `useXcodeAssetCompanionFile` are not set, this value is ignored
     - `useXcodeAssetCompanionFile`: A shorthand to create xcode assets `Contents.json` companion files. Ignored if `companionFileName` is set
+- `templates`: A map of Jinja templates that you can reference from the exports filter/fileNames variable. 
 
 ## Templating
 The templating engine uses Jinja syntax. You can use loops, if statements and more. FigEx's templating is build with [jinjava](https://github.com/HubSpot/jinjava) which is also the base of HubSpot's [HubL templating system](https://developers.hubspot.com/docs/cms/hubl). This means the syntax for if-statements and loops also applies to FigEx, same goes for the filters available. Of course, HubSpot specific variables and functions are not available.
@@ -299,6 +300,12 @@ Hint: You can also use Jinja filters to modify the name, e.g. `{{ color.name|low
 - `scale`: The scale as floating point number as configured
 - `name_prefix`: The prefix of the filename as configured
 - `name_suffix`: The suffix of the filename as configured
+
+### Referencing a template
+You can also reference a template from the root `templates` map. Reference a template by placing a dollar sign in front of the key.
+```
+"filter": "$templateKey",
+```
 
 ## Build the project
 - Clone the Git

--- a/figex-core/src/main/kotlin/com/iodigital/figex/FigEx.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/FigEx.kt
@@ -168,6 +168,7 @@ object FigEx {
             values = values,
             components = components,
             root = root,
+            templates = config.templates,
         )
     }
 
@@ -204,6 +205,7 @@ object FigEx {
                     components = components,
                     root = root,
                     exporter = exporter,
+                    templates = config.templates,
                 )
             }
         }.joinAll()

--- a/figex-core/src/main/kotlin/com/iodigital/figex/IconExports.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/IconExports.kt
@@ -3,6 +3,8 @@ package com.iodigital.figex
 import com.iodigital.figex.api.FigmaApi
 import com.iodigital.figex.api.FigmaImageExporter
 import com.iodigital.figex.ext.asFigExComponent
+import com.iodigital.figex.ext.findFileNames
+import com.iodigital.figex.ext.findFilter
 import com.iodigital.figex.models.figex.FigExComponent
 import com.iodigital.figex.models.figex.FigExConfig
 import com.iodigital.figex.models.figex.FigExConfig.Export.Icons.Companion.COMPANION_FILENAME_XCODE_ASSETS
@@ -33,6 +35,7 @@ internal suspend fun performIconExport(
     file: FigmaFile,
     components: List<FigExComponent>,
     exporter: FigmaImageExporter,
+    templates: Map<String, String>,
 ) = withContext(Dispatchers.IO) {
     //region Make destination
     val destinations = export.destinationPaths.takeIf { it.isNotEmpty() } ?: listOf(export.destinationPath)
@@ -53,9 +56,9 @@ internal suspend fun performIconExport(
             Triple(component, it, createTemplateContext(file, it, component))
         }
     }.filter { (_, _, context) ->
-        filter(filter = export.filter, context = context)
+        filter(filter = export.findFilter(templates), context = context)
     }.toList().map { (component, scale, context) ->
-        val name = jinjava.render(export.fileNames, context).trim().replace("\n", "")
+        val name = jinjava.render(export.findFileNames(templates), context).trim().replace("\n", "")
 
         ComponentExport(
             component = component,

--- a/figex-core/src/main/kotlin/com/iodigital/figex/ValueExports.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/ValueExports.kt
@@ -1,6 +1,7 @@
 package com.iodigital.figex
 
 import com.iodigital.figex.api.FigmaApi
+import com.iodigital.figex.ext.findFilter
 import com.iodigital.figex.ext.walk
 import com.iodigital.figex.models.figex.FigExArgbColor
 import com.iodigital.figex.models.figex.FigExComponent
@@ -124,13 +125,14 @@ internal fun performValuesExport(
     file: FigmaFile,
     values: List<FigExValue<*>>,
     components: List<FigExComponent>,
+    templates: Map<String, String>,
 ) {
     val context = createTemplateContext(
         file = file,
         defaultMode = export.defaultMode ?: "",
         values = values,
         components = components,
-        filter = export.filter,
+        filter = export.findFilter(templates),
     ) + export.templateVariables
     val template = root.makeChild(export.templatePath)
     val destinations = export.destinationPaths.takeIf { it.isNotEmpty() } ?: listOf(export.destinationPath)

--- a/figex-core/src/main/kotlin/com/iodigital/figex/ext/FigExConfigExt.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/ext/FigExConfigExt.kt
@@ -1,0 +1,21 @@
+package com.iodigital.figex.ext
+
+import com.iodigital.figex.models.figex.FigExConfig
+
+internal fun FigExConfig.Export.findFilter(templates: Map<String, String>): String = when (this) {
+    is FigExConfig.Export.Icons -> this.filter
+    is FigExConfig.Export.Values -> this.filter
+}.findTemplateOrThis(templates)
+
+internal fun FigExConfig.Export.Icons.findFileNames(templates: Map<String, String>): String =
+    fileNames.findTemplateOrThis(templates)
+
+private fun String.findTemplateOrThis(templates: Map<String, String>): String {
+    if (startsWith("$")) {
+        val key = drop(1)
+        return templates.getOrElse(key) {
+            throw IllegalArgumentException("Filter with id '$key' does not exist in the filter map")
+        }
+    }
+    return this
+}

--- a/figex-core/src/main/kotlin/com/iodigital/figex/models/figex/FigExConfig.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/models/figex/FigExConfig.kt
@@ -9,6 +9,7 @@ data class FigExConfig(
     val figmaFileKey: String,
     val modeAliases: Map<String, String> = emptyMap(),
     val exports: List<@Polymorphic Export>,
+    val templates: Map<String, String> = emptyMap(),
 ) {
     @Serializable
     sealed class Export {

--- a/figex-core/src/test/kotlin/com/iodigital/figex/ext/FigExConfigExtKtTest.kt
+++ b/figex-core/src/test/kotlin/com/iodigital/figex/ext/FigExConfigExtKtTest.kt
@@ -1,0 +1,98 @@
+package com.iodigital.figex.ext
+
+import com.iodigital.figex.models.figex.FigExConfig.Export
+import com.iodigital.figex.models.figex.FigExIconFormat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FigExConfigExtKtTest {
+
+    // FindFilter
+
+    @Test
+    fun `WHEN no dollar sign is present THEN literal filter for Values export is returned`() {
+        val export = Export.Values(templatePath = "template.txt", filter = "name == 'color'")
+        val result = export.findFilter(emptyMap())
+        assertEquals("name == 'color'", result)
+    }
+
+    @Test
+    fun `WHEN no dollar sign is present THEN literal filter for Icons export is returned`() {
+        val export = Export.Icons(format = FigExIconFormat.Svg, filter = "name == 'icon'")
+        val result = export.findFilter(emptyMap())
+        assertEquals("name == 'icon'", result)
+    }
+
+    @Test
+    fun `WHEN no filter is present THEN default filter value is returned`() {
+        val export = Export.Values(templatePath = "template.txt")
+        val result = export. findFilter(emptyMap())
+        assertEquals("true", result)
+    }
+
+    @Test
+    fun `WHEN reference is correct for Values export THEN correct filter is resolved`() {
+        val export = Export.Values(templatePath = "template.txt", filter = "\$colors")
+        val filters = mapOf("colors" to "type == 'COLOR'")
+        val result = export. findFilter(filters)
+        assertEquals("type == 'COLOR'", result)
+    }
+
+    @Test
+    fun `WHEN reference is correct for Icons export THEN correct filter is resolved`() {
+        val export = Export.Icons(format = FigExIconFormat.Svg, filter = "\$myIcons")
+        val filters = mapOf("myIcons" to "component == 'icon'")
+        val result = export. findFilter(filters)
+        assertEquals("component == 'icon'", result)
+    }
+
+    @Test
+    fun `WHEN filter does not exists THEN error is thrown`() {
+        val export = Export.Values(templatePath = "template.txt", filter = "\$missing")
+        assertFailsWith<IllegalArgumentException> {
+            export. findFilter(emptyMap())
+        }
+    }
+
+    @Test
+    fun `WHEN referenced filter does not exist THEN error is thrown`() {
+        val export = Export.Icons(format = FigExIconFormat.Svg, filter = "\$unknown")
+        assertFailsWith<IllegalArgumentException> {
+            export. findFilter(mapOf("other" to "value"))
+        }
+    }
+
+    @Test
+    fun `WHEN no dollar sign present THEN filter is not resolved`() {
+        val export = Export.Values(templatePath = "template.txt", filter = "colors")
+        val filters = mapOf("colors" to "type == 'COLOR'")
+        val result = export. findFilter(filters)
+        assertEquals("colors", result)
+    }
+
+    @Test
+    fun `WHEN dollar sign is empty THEN nothing happens`() {
+        val export = Export.Values(templatePath = "template.txt", filter = "\$")
+        val filters = mapOf("" to "empty-key-value")
+        val result = export. findFilter(filters)
+        assertEquals("empty-key-value", result)
+    }
+
+    // FindFileNames
+
+    @Test
+    fun `WHEN fileNames has no dollar sign THEN literal filter is returned`() {
+        val export = Export.Icons(format = FigExIconFormat.Svg, fileNames = "name == 'icon'")
+        val result = export.findFileNames(emptyMap())
+        assertEquals("name == 'icon'", result)
+    }
+
+    @Test
+    fun `WHEN fileNames reference is correct THEN correct filter is resolved`() {
+        val export = Export.Icons(format = FigExIconFormat.Svg, fileNames = "\$myIcons")
+        val filters = mapOf("myIcons" to "component == 'icon'")
+        val result = export. findFileNames(filters)
+        assertEquals("component == 'icon'", result)
+    }
+}

--- a/samples/config.json
+++ b/samples/config.json
@@ -67,7 +67,7 @@
     {
       "type": "icons",
       "format": "androidxml",
-      "filter": "{% if full_name|startsWith('content', true) %} true {% else %} false {% endif %}",
+      "filter": "$contentFilter",
       "fileNames": "{{ full_name|replaceSpecialChars('_')|lowercase }}",
       "destinationPath": "../sample_output/icons/drawable",
       "clearDestination": true
@@ -75,7 +75,7 @@
     {
       "type": "icons",
       "format": "webp",
-      "filter": "{% if full_name|startsWith('content', true) %} true {% else %} false {% endif %}",
+      "filter": "$contentFilter",
       "fileNames": "{{ full_name|replaceSpecialChars('_')|lowercase }}",
       "destinationPath": "../sample_output/icons",
       "clearDestination": true,
@@ -84,11 +84,15 @@
     {
       "type": "icons",
       "format": "pdf",
-      "filter": "{% if full_name|startsWith('content', true) %} true {% else %} false {% endif %}",
-      "fileNames": "{{ full_name|replaceSpecialChars('_')|lowercase }}.imageasset/{{ full_name|replaceSpecialChars('_')|lowercase }}",
+      "filter": "$contentFilter",
+      "fileNames": "$iconFileName",
       "destinationPath": "../sample_output/Media.xcassets",
       "clearDestination": true,
       "useXcodeAssetCompanionFile": true
     }
-  ]
+  ],
+  "templates": {
+    "contentFilter": "{% if full_name|startsWith('content', true) %} true {% else %} false {% endif %}",
+    "iconFileName": "{{ full_name|replaceSpecialChars('_')|lowercase }}.imageasset/{{ full_name|replaceSpecialChars('_')|lowercase }}"
+  }
 }


### PR DESCRIPTION
By adding a template variable in the config file, we can add jinja templates that we can reference with a key. In the current setup we have to repeat the same filter for multiple export blocks. With this change we can place the templateKey in the filter value and the correct template will be picked up. 