### PR TITLE
Add fill rule attribute when not set by figma

### DIFF
--- a/figex-core/src/main/java/com/android/ide/common/Svg2Vector.java
+++ b/figex-core/src/main/java/com/android/ide/common/Svg2Vector.java
@@ -64,6 +64,7 @@ public class Svg2Vector {
     public static final String SVG_FILL_COLOR = "fill";
     public static final String SVG_FILL_OPACITY = "fill-opacity";
     public static final String SVG_OPACITY = "opacity";
+    public static final String SVG_FILL_RULE = "fill-rule";
     public static final String SVG_CLIP = "clip";
     public static final String SVG_POINTS = "points";
 
@@ -76,6 +77,7 @@ public class Svg2Vector {
             .put(SVG_STROKE_WIDTH, "android:strokeWidth")
             .put(SVG_FILL_COLOR, "android:fillColor")
             .put(SVG_FILL_OPACITY, "android:fillAlpha")
+            .put(SVG_FILL_RULE, "android:fillType")
             .put(SVG_CLIP, "android:clip")
             .put(SVG_OPACITY, "android:fillAlpha")
             .build();

--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
@@ -287,6 +287,7 @@ class FigmaApi(
                                     message = "  Inline converting SVG => Android XML: $tmpFile"
                                 )
                                 require(tmpFile.length() > 0) { "Empty SVG file for $id" }
+                                SvgCompoundPathFix.addMissingFillRuleToCompoundPaths(tmpFile)
                                 Svg2Vector.parseSvgToXml(tmpFile, out)
                             }
 

--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/SvgCompoundPathFix.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/SvgCompoundPathFix.kt
@@ -1,0 +1,51 @@
+package com.iodigital.figex.api
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+/**
+ * Figma's Images API sometimes omits fill-rule="evenodd" from SVG paths that need it,
+ * causing compound paths (with cutout shapes) to render as solid blobs in Android
+ * VectorDrawables. This utility detects compound paths (multiple subpaths) and adds
+ * fill-rule="evenodd" when missing.
+ */
+object SvgCompoundPathFix {
+
+    fun addMissingFillRuleToCompoundPaths(svgFile: File) {
+        val factory = DocumentBuilderFactory.newInstance()
+        val builder = factory.newDocumentBuilder()
+        val doc = builder.parse(svgFile)
+        val paths = doc.getElementsByTagName("path")
+        var modified = false
+
+        for (i in 0 until paths.length) {
+            val path = paths.item(i) as? org.w3c.dom.Element ?: continue
+            val d = path.getAttribute("d").orEmpty()
+            val fillRule = path.getAttribute("fill-rule").orEmpty()
+
+            if (fillRule.isEmpty() && hasMultipleSubpaths(d)) {
+                path.setAttribute("fill-rule", "evenOdd")
+                modified = true
+            }
+        }
+
+        if (modified) {
+            val transformer = TransformerFactory.newInstance().newTransformer()
+            transformer.transform(DOMSource(doc), StreamResult(svgFile))
+        }
+    }
+
+    private fun hasMultipleSubpaths(d: String): Boolean {
+        var count = 0
+        for (char in d) {
+            if (char == 'M' || char == 'm') {
+                count++
+                if (count > 1) return true
+            }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
Figma's Images API sometimes omits fill-rule="evenodd" from SVG paths that need it, causing compound paths (with cutout shapes) to render as solid blobs in Android VectorDrawables. This utility detects compound paths (multiple subpaths) and adds fill-rule="evenodd" when missing.