### PR TITLE
Add support for android:fillType in vector drawables

### DIFF
--- a/figex-core/src/main/java/com/android/ide/common/Svg2Vector.java
+++ b/figex-core/src/main/java/com/android/ide/common/Svg2Vector.java
@@ -64,6 +64,7 @@ public class Svg2Vector {
     public static final String SVG_FILL_COLOR = "fill";
     public static final String SVG_FILL_OPACITY = "fill-opacity";
     public static final String SVG_OPACITY = "opacity";
+    public static final String SVG_FILL_RULE = "fill-rule";
     public static final String SVG_CLIP = "clip";
     public static final String SVG_POINTS = "points";
 
@@ -76,6 +77,7 @@ public class Svg2Vector {
             .put(SVG_STROKE_WIDTH, "android:strokeWidth")
             .put(SVG_FILL_COLOR, "android:fillColor")
             .put(SVG_FILL_OPACITY, "android:fillAlpha")
+            .put(SVG_FILL_RULE, "android:fillType")
             .put(SVG_CLIP, "android:clip")
             .put(SVG_OPACITY, "android:fillAlpha")
             .build();

--- a/figex-core/src/main/java/com/android/ide/common/SvgLeafNode.java
+++ b/figex-core/src/main/java/com/android/ide/common/SvgLeafNode.java
@@ -221,6 +221,8 @@ class SvgLeafNode extends SvgNode {
                 }
             } else if (colorMap.containsKey(vdValue.toLowerCase())) {
                 vdValue = colorMap.get(vdValue.toLowerCase());
+            } else if (vdValue.equals("evenodd")) {
+                vdValue = "evenOdd";
             }
             String attr = "\n        " + vectorDrawableAttr + "=\"" +
                           vdValue + "\"";


### PR DESCRIPTION
The svg property fill-rule was not converted to fillType when converting to vector drawables. 