### PR TITLE
Cache figma node data and only fetch file when updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ FigEx can be run standalone from the shell. This options is not recommended, pre
 ```shell
  export FIGMA_TOKEN="Figma token"
  figex -c "path to your config"
+ figex -c "path to your config" --no-cache  # Force refetch all data
 ```
 
 #### Windows
@@ -139,6 +140,7 @@ The following properties can be configured in the `figex` block:
 | `ignoreUnsupportedLinks`  | `Boolean`    | `false` | Ignore unsupported external variable links instead of failing                        |
 | `showStatus`              | `Boolean`    | `true`  | Show the animated status line during export                                          |
 | `idsChunkSize`            | `Int`        | `60`    | Number of node IDs to request per API call. Higher values may help avoid rate limits |
+| `noCache`                 | `Boolean`    | `false` | Skip reading the node cache and refetch all data from Figma                          |
 
 ## Setup in Figma
 Nothing to do here really! All you need is the file key from the URL. You can then use this in the configuration (see below).
@@ -306,6 +308,27 @@ You can also reference a template from the root `templates` map. Reference a tem
 ```
 "filter": "$templateKey",
 ```
+
+## Caching and rate limits
+
+FigEx caches node data fetched from the Figma API to avoid hitting rate limits on subsequent runs. The cache is stored in a `figex_cache/` directory next to your config file, keyed by the Figma file key. This directory can be committed to your repository so that team members and CI don't need to refetch unchanged data.
+
+**How it works:**
+- On the first run, FigEx fetches all required data and saves it to `figex_cache/{figmaFileKey}.json`
+- On subsequent runs, if the file's `lastModified` timestamp hasn't changed, cached node data is used (only 1 API request for the file metadata)
+- If the file has been modified in Figma, the cache is invalidated and data is refetched
+
+**Forcing a refresh:**
+```shell
+figex -c "path/to/config.json" --no-cache
+```
+
+**Rate limit errors:**
+Figma applies strict rate limits based on your seat type. If the API returns a retry wait time over 10 minutes, FigEx will stop with an error indicating:
+- Your plan tier (e.g., `org`, `pro`)
+- Your seat type (`low` = View/Collab, `high` = Dev/Full Design)
+
+View and Collab seats can have very restrictive limits. If you hit these limits, use a personal access token from a user with a **Dev** or **Full Design** seat.
 
 ## Build the project
 - Clone the Git

--- a/figex-cli/src/commonMain/kotlin/com/iodigital/figex/Main.kt
+++ b/figex-cli/src/commonMain/kotlin/com/iodigital/figex/Main.kt
@@ -59,6 +59,12 @@ fun main(args: Array<String>): Unit = runBlocking {
             fullName = "ids-chunk-size",
             description = "Amount of IDs to download simultaneously",
         )
+        val noCache by parser.option(
+            ArgType.Boolean,
+            shortName = "nc",
+            fullName = "no-cache",
+            description = "Ignore node cache and refetch all data from Figma",
+        )
         parser.parse(args)
 
 
@@ -70,6 +76,7 @@ fun main(args: Array<String>): Unit = runBlocking {
             showStatus = status ?: FigEx.DEFAULT_SHOW_STATUS,
             ignoreUnsupportedLinks = ignoreUnsupportedLinks ?: FigEx.DEFAULT_IGNORE_UNSUPPORTED_LINKS,
             idsChunkSize = idsChunkSize ?: FigEx.DEFAULT_IDS_CHUNK_SIZE,
+            noCache = noCache ?: FigEx.DEFAULT_NO_CACHE,
         )
 
         exitProcess(0)

--- a/figex-core/src/main/kotlin/com/iodigital/figex/FigEx.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/FigEx.kt
@@ -32,6 +32,7 @@ object FigEx {
     const val DEFAULT_IGNORE_UNSUPPORTED_LINKS = false
     const val DEFAULT_SHOW_STATUS = true
     const val DEFAULT_IDS_CHUNK_SIZE = 60
+    const val DEFAULT_NO_CACHE = false
 
     fun exportBlocking(
         configFile: File,
@@ -41,6 +42,7 @@ object FigEx {
         ignoreUnsupportedLinks: Boolean = DEFAULT_IGNORE_UNSUPPORTED_LINKS,
         showStatus: Boolean = DEFAULT_SHOW_STATUS,
         idsChunkSize: Int = DEFAULT_IDS_CHUNK_SIZE,
+        noCache: Boolean = DEFAULT_NO_CACHE,
     ) = runBlocking {
         export(
             configFile = configFile,
@@ -50,6 +52,7 @@ object FigEx {
             showStatus = showStatus,
             ignoreUnsupportedLinks = ignoreUnsupportedLinks,
             idsChunkSize = idsChunkSize,
+            noCache = noCache,
         )
     }
 
@@ -61,6 +64,7 @@ object FigEx {
         ignoreUnsupportedLinks: Boolean = DEFAULT_IGNORE_UNSUPPORTED_LINKS,
         showStatus: Boolean = DEFAULT_SHOW_STATUS,
         idsChunkSize: Int = DEFAULT_IDS_CHUNK_SIZE,
+        noCache: Boolean = DEFAULT_NO_CACHE,
     ) {
         com.iodigital.figex.utils.showStatus = showStatus
         com.iodigital.figex.utils.debugLogs = debugLogs
@@ -71,6 +75,7 @@ object FigEx {
             figmaToken = figmaToken,
             ignoreUnsupportedLinks = ignoreUnsupportedLinks,
             idsChunkSize = idsChunkSize,
+            noCache = noCache,
         )
     }
 
@@ -79,6 +84,7 @@ object FigEx {
         figmaToken: String,
         ignoreUnsupportedLinks: Boolean,
         idsChunkSize: Int,
+        noCache: Boolean,
     ) = withContext(Dispatchers.IO) {
         val exportScope = CoroutineScope(Dispatchers.IO)
         try {
@@ -104,6 +110,15 @@ object FigEx {
                     idsChunkSize = idsChunkSize,
                 )
             val file = loadFigmaFile(config = config, api = api)
+
+            val cacheFile = File(
+                configFile.absoluteFile.parentFile,
+                "figex_cache/${config.figmaFileKey}.json"
+            )
+            if (!noCache) {
+                api.loadCache(cacheFile, file.lastModified)
+            }
+
             val components = async {
                 loadComponents(api = api, file = file).distinctBy { it.key }
             }
@@ -111,14 +126,19 @@ object FigEx {
                 loadValues(config = config, api = api, file = file)
             }
 
+            val resolvedComponents = components.await()
+            val resolvedValues = values.await()
+
+            api.saveCache(cacheFile, file.lastModified)
+
             listOf(
                 launch {
                     performValueExports(
                         root = configFile.absoluteFile.parentFile,
                         file = file,
                         config = config,
-                        values = values.await(),
-                        components = components.await(),
+                        values = resolvedValues,
+                        components = resolvedComponents,
                     )
                 },
                 launch {
@@ -126,7 +146,7 @@ object FigEx {
                         root = configFile.absoluteFile.parentFile,
                         file = file,
                         config = config,
-                        components = components.await(),
+                        components = resolvedComponents,
                         exporter = api
                     )
                 }

--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
@@ -16,9 +16,11 @@ import com.iodigital.figex.models.figex.FigExValue
 import com.iodigital.figex.models.figma.FigmaFile
 import com.iodigital.figex.models.figma.FigmaImageExport
 import com.iodigital.figex.models.figma.FigmaNode
+import com.iodigital.figex.models.figma.FigmaNodesCache
 import com.iodigital.figex.models.figma.FigmaNodesList
 import com.iodigital.figex.models.figma.FigmaVariableReference
 import com.iodigital.figex.models.figma.FigmaVariableValue
+import com.iodigital.figex.serializer.DefaultJson
 import com.iodigital.figex.utils.cacheDir
 import com.iodigital.figex.utils.debug
 import com.iodigital.figex.utils.info
@@ -53,6 +55,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
 import java.io.File
 import java.io.IOException
 import java.io.OutputStream
@@ -60,6 +63,7 @@ import java.lang.Math.random
 import java.util.Collections.emptyList
 import java.util.Collections.emptyMap
 import java.util.UUID
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(FlowPreview::class)
@@ -77,6 +81,7 @@ class FigmaApi(
     private val completedRequestCount = MutableStateFlow(0)
     private val queueCount = MutableStateFlow(0)
     private val requestLeases = Semaphore(32)
+    private val nodeCache: MutableMap<String, FigmaNode> = mutableMapOf()
 
     init {
         scope.launch {
@@ -111,6 +116,38 @@ class FigmaApi(
         }.body<FigmaFile>().copy(
             fileKey = fileKey
         )
+    }
+
+    fun loadCache(cacheFile: File, lastModified: String) {
+        if (!cacheFile.exists()) {
+            info(tag, "No node cache found")
+            return
+        }
+        try {
+            val cached = DefaultJson.decodeFromString<FigmaNodesCache>(cacheFile.readText())
+            if (cached.lastModified == lastModified) {
+                nodeCache.putAll(cached.nodes)
+                info(tag, "Loaded ${cached.nodes.size} nodes from cache")
+            } else {
+                info(tag, "Cache outdated (file modified), will refetch nodes")
+            }
+        } catch (e: Exception) {
+            warning(tag, "Failed to read node cache: ${e.message}")
+        }
+    }
+
+    fun saveCache(cacheFile: File, lastModified: String) {
+        try {
+            cacheFile.parentFile.mkdirs()
+            val cache = FigmaNodesCache(
+                lastModified = lastModified,
+                nodes = nodeCache.toMap()
+            )
+            cacheFile.writeText(DefaultJson.encodeToString(cache))
+            info(tag, "Saved ${nodeCache.size} nodes to cache")
+        } catch (e: Exception) {
+            warning(tag, "Failed to write node cache: ${e.message}")
+        }
     }
 
     internal suspend fun loadVariable(
@@ -149,24 +186,39 @@ class FigmaApi(
                 return@withRateLimit FigmaNodesList(emptyMap())
             }
 
-            ids.chunked(idsChunkSize).map { idsChunk ->
-                withQueue {
-                    httpClient.get {
-                        figmaRequest("v1/files/$fileKey/nodes")
-                        parameter("ids", idsChunk.joinToString(","))
-                    }.body<FigmaNodesList>()
-                }
-            }.flatMap {
-                it.nodes.entries
-            }.associate {
-                it.key to it.value
-            }.let {
-                FigmaNodesList(it).resolveNestedReferences(
-                    this,
-                    emptyList(),
-                    ignoreUnsupportedLinks
-                )
+            val cachedNodes = ids.filter { it in nodeCache }.associateWith { nodeCache[it]!! }
+            val uncachedIds = ids - cachedNodes.keys
+
+            if (cachedNodes.isNotEmpty() && uncachedIds.isEmpty()) {
+                debug(tag, "All ${ids.size} nodes loaded from cache")
+            } else if (cachedNodes.isNotEmpty()) {
+                debug(tag, "${cachedNodes.size} nodes from cache, fetching ${uncachedIds.size} from API")
             }
+
+            val fetchedNodes = if (uncachedIds.isEmpty()) {
+                emptyMap()
+            } else {
+                uncachedIds.chunked(idsChunkSize).map { idsChunk ->
+                    withQueue {
+                        httpClient.get {
+                            figmaRequest("v1/files/$fileKey/nodes")
+                            parameter("ids", idsChunk.joinToString(","))
+                        }.body<FigmaNodesList>()
+                    }
+                }.flatMap {
+                    it.nodes.entries
+                }.associate {
+                    it.key to it.value
+                }
+            }
+
+            nodeCache.putAll(fetchedNodes)
+
+            FigmaNodesList(cachedNodes + fetchedNodes).resolveNestedReferences(
+                this,
+                emptyList(),
+                ignoreUnsupportedLinks
+            )
         }
     }
 
@@ -204,9 +256,20 @@ class FigmaApi(
             if (e.response.status.value == 429) {
                 val first = rateLimitReached.getAndUpdate { true }
                 if (!first) {
-                    val delay =
-                        e.response.headers[HttpHeaders.RetryAfter]?.toLongOrNull()?.seconds?.plus(5.seconds)
-                            ?: 10.seconds
+                    val retryAfterSeconds =
+                        e.response.headers[HttpHeaders.RetryAfter]?.toLongOrNull()
+                    val delay = retryAfterSeconds?.seconds?.plus(5.seconds) ?: 10.seconds
+                    val planTier = e.response.headers["x-figma-plan-tier"]
+                    val rateLimitType = e.response.headers["x-figma-rate-limit-type"]
+
+                    if (retryAfterSeconds != null && retryAfterSeconds > 10.minutes.inWholeSeconds) {
+                        throw FigmaRateLimitException(
+                            retryAfter = delay,
+                            planTier = planTier,
+                            rateLimitType = rateLimitType,
+                        )
+                    }
+
                     warning(tag = tag, message = "Rate limit reached, delaying for $delay")
                     e.response.headers
                         .filter { key, _ -> key.startsWith("x-figma", ignoreCase = true) }

--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaRateLimitException.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaRateLimitException.kt
@@ -1,0 +1,24 @@
+package com.iodigital.figex.api
+
+import kotlin.time.Duration
+
+class FigmaRateLimitException(
+    val retryAfter: Duration,
+    val planTier: String?,
+    val rateLimitType: String?,
+) : RuntimeException(
+    buildString {
+        appendLine("Figma API rate limit reached. Retry after: $retryAfter")
+        appendLine()
+        appendLine("  Plan tier: ${planTier ?: "unknown"}")
+        appendLine("  Seat type: ${rateLimitType ?: "unknown"} (low = View/Collab, high = Dev/Full Design)")
+        appendLine()
+        if (rateLimitType == "low") {
+            appendLine("Your token belongs to a user with a View or Collab seat, which has very")
+            appendLine("restrictive rate limits (as low as 6 requests/month for file endpoints).")
+            appendLine("Use a token from a user with a Dev or Full Design seat for higher limits.")
+        } else {
+            appendLine("Consider reducing the number of parallel requests or waiting before retrying.")
+        }
+    }
+)

--- a/figex-core/src/main/kotlin/com/iodigital/figex/models/figma/FigmaNodesCache.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/models/figma/FigmaNodesCache.kt
@@ -1,0 +1,9 @@
+package com.iodigital.figex.models.figma
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class FigmaNodesCache(
+    val lastModified: String,
+    val nodes: Map<String, FigmaNode>
+)

--- a/gradle-plugin/src/main/kotlin/com/iodigital/figex/ExportFigmaTask.kt
+++ b/gradle-plugin/src/main/kotlin/com/iodigital/figex/ExportFigmaTask.kt
@@ -26,6 +26,7 @@ open class ExportFigmaTask : DefaultTask() {
                     ignoreUnsupportedLinks = ignoreUnsupportedLinks,
                     showStatus = showStatus,
                     idsChunkSize = idsChunkSize,
+                    noCache = noCache,
                 )
             }
         }

--- a/gradle-plugin/src/main/kotlin/com/iodigital/figex/FigExExtensions.kt
+++ b/gradle-plugin/src/main/kotlin/com/iodigital/figex/FigExExtensions.kt
@@ -12,4 +12,5 @@ open class FigExExtension(@Suppress("UNUSED_PARAMETER") project: Project) {
     var ignoreUnsupportedLinks: Boolean = FigEx.DEFAULT_IGNORE_UNSUPPORTED_LINKS
     var showStatus: Boolean = FigEx.DEFAULT_SHOW_STATUS
     var idsChunkSize: Int = FigEx.DEFAULT_IDS_CHUNK_SIZE
+    var noCache: Boolean = FigEx.DEFAULT_NO_CACHE
 }


### PR DESCRIPTION
Context

Figma's rate limits for View/Collab seat tokens (rate-limit-type "low") allow only ~6 requests/month on Tier 1 endpoints (file/nodes). The first file request succeeds but subsequent node requests immediately get 429 with a multi-day Retry-After. By caching node responses next to the config file (so it can be checked into the repo), subsequent runs reuse cached data when the file hasn't changed — reducing API calls from N+1 to just 1.

Approach

Add an in-memory node cache to FigmaApi backed by a JSON file stored relative to the config file.

Cache location

{configFile.parent}/figex_cache/{figmaFileKey}.json

Cache format (new @Serializable data class)

     @Serializable
     data class FigmaNodesCache(
         val lastModified: String,
         val nodes: Map<String, FigmaNode>
     )

Flow

     1. FigEx.doExport() loads the file (1 API request, gets lastModified)
     2. If cache file exists and lastModified matches → pre-populate FigmaApi's in-memory node map
     3. In FigmaApi.loadNodes(), check in-memory cache before making API calls — only fetch IDs not in cache
     4. After all loading succeeds, save the accumulated node cache to disk
