### PR TITLE
Retry loading images with smaller chunk

### DIFF
--- a/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
+++ b/figex-core/src/main/kotlin/com/iodigital/figex/api/FigmaApi.kt
@@ -236,13 +236,14 @@ class FigmaApi(
         out: suspend (String, suspend (OutputStream) -> Unit) -> Unit
     ) {
         withContext(Dispatchers.IO) {
-            val downloadUrls = ids.chunked(idsChunkSize).map { idsChunk ->
-                debug(tag, "Loading images: $idsChunk")
-                withRateLimit {
+            val downloadUrls = ids.chunked(idsChunkSize).mapNotNull { idsChunk ->
+
+                suspend fun fetchChunk(chunk: List<String>): FigmaImageExport = withRateLimit {
+                    debug(tag, "Loading images: $chunk")
                     withQueue {
                         httpClient.get {
                             figmaRequest("v1/images/$fileKey")
-                            parameter("ids", idsChunk.joinToString(","))
+                            parameter("ids", chunk.joinToString(","))
                             parameter("scale", scale)
                             parameter(
                                 key = "format",
@@ -253,6 +254,25 @@ class FigmaApi(
                                 }
                             )
                         }.body<FigmaImageExport>()
+                    }
+                }
+
+                try {
+                    fetchChunk(idsChunk)
+                } catch (e: ClientRequestException) {
+                    if (e.response.status.value == 400) {
+                        warning(tag, "Retry failed for chunk $idsChunk with size $idsChunkSize")
+                        val retryChunkSize = (idsChunkSize / 2).coerceAtMost(15)
+                        warning(tag, "Retrying with smaller chunk size $retryChunkSize")
+                        idsChunk.chunked(retryChunkSize)
+                            .flatMap { chunk ->
+                                fetchChunk(chunk).images.entries
+                            }
+                            .associate { it.key to it.value }
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { FigmaImageExport(images = it, err = null) }
+                    } else {
+                        throw e
                     }
                 }
             }.flatMap { body ->


### PR DESCRIPTION
With the default chunksize, for most cases the export runs sucessfuly. For one project I noticed an error where it returned with a 400 error:
```
* What went wrong:
Execution failed for task ':exportFigma'.
> Client request(GET https://api.figma.com/v1/images/redacted?ids=redacted&scale=3.0&format=png) invalid: 400 . Text: "{"status":400,"err":"Render timeout, try requesting fewer or smaller images"}"
```
In the figma project I could not find an image that was exceeding the max size. I tried to run the webcall with fewer ids and that was successful. This fix will split the ids in multiple chunks when the error occurs. Then do multiple calls based on the amount of the new retry chunks. 
With 30 ids per chunk it still failed so I capped the chunksize to 15